### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-out
-node_modules
+out/
+node_modules/
 .vscode-test/
 *.vsix
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ## Features
 
-This extension allows you to download and open a git repository directly from VS Code.
+This extension allows you to download and open a Git repository directly from VS Code.
 
 The following repository locations/formats are supported:
-- NPM package name (e.g. `lodash`)
-- Github repository URL (e.g. `https://github.com/lodash/lodash`)
+- npm package name (e.g. `lodash`)
+- GitHub repository URL (e.g. `https://github.com/lodash/lodash`)
 - Git HTTP endpoint (e.g. `https://github.com/lodash/lodash.git`)
 - Git SSH endpoint (e.g. `git@github.com:lodash/lodash.git`)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dingo-vscode",
   "displayName": "Dingo",
-  "description": "Allows you to download and open a git repository directly from VS Code",
+  "description": "Allows you to download and open a Git repository directly from VS Code",
   "version": "1.0.5",
   "author": "Wallaby.js",
   "homepage": "https://wallabyjs.com/dingo/",
@@ -46,7 +46,7 @@
           "default": ""
         },
         "dingo.npmPath": {
-          "description": "Explicitly set NPM path for installing packages.",
+          "description": "Explicitly set npm path for installing packages.",
           "type": "string",
           "default": ""
         },


### PR DESCRIPTION
Just a small update to `.gitignore` and a couple of minor typo fixes:

`NPM` -> `npm`
`Github` -> `GitHub`

I just found out about wallabyjs. Really cool :+1: